### PR TITLE
chore: Remove hardcoded npm audit check label

### DIFF
--- a/templates/issueCreation.template
+++ b/templates/issueCreation.template
@@ -6,7 +6,6 @@
             "name": "Security Vulnerability"
         },
         "labels": [
-            "npm_audit_check",
             "Security"
         ],
         "description": "{{ISSUE_DESCRIPTION}}"


### PR DESCRIPTION
Removing the `npm_audit_check` label for the issue creation template since it's highly tight with the `npm audit` tool.