### PR TITLE
fix: properly retrieve AWSELB cookie

### DIFF
--- a/helpers/jira-helpers.js
+++ b/helpers/jira-helpers.js
@@ -8,13 +8,8 @@ const createJiraSession = async function createJiraSession (
   jiraUser,
   jiraPassword
 ) {
-  const LOAD_BALANCER_COOKIE_ENABLED =
-    core.getInput('LOAD_BALANCER_COOKIE_ENABLED') === 'true' ||
-    process.env.LOAD_BALANCER_COOKIE_ENABLED === 'true';
-  const LOAD_BALANCER_COOKIE_NAME =
-    core.getInput('LOAD_BALANCER_COOKIE_NAME') ||
-    process.env.LOAD_BALANCER_COOKIE_NAME ||
-    '';
+  const LOAD_BALANCER_COOKIE_ENABLED = core.getInput('LOAD_BALANCER_COOKIE_ENABLED') === 'true' || process.env.LOAD_BALANCER_COOKIE_ENABLED === 'true';
+  const LOAD_BALANCER_COOKIE_NAME = core.getInput('LOAD_BALANCER_COOKIE_NAME') || process.env.LOAD_BALANCER_COOKIE_NAME || '';
 
   const sessionPayload = {
     username: jiraUser,
@@ -47,13 +42,13 @@ const createJiraSession = async function createJiraSession (
   };
 
   if (LOAD_BALANCER_COOKIE_ENABLED) {
-    const LOAD_BALANCER = response.headers[0]['set-cookie'][0];
+    const LOAD_BALANCER = response.headers['set-cookie'][0];
     const LOAD_BALANCER_HEADER = `${LOAD_BALANCER_COOKIE_NAME}=`;
-    const LOAD_BALANCER_HEADER_LENGTH =
-      LOAD_BALANCER.indexOf(LOAD_BALANCER_HEADER) + LOAD_BALANCER_HEADER.length;
+    const LOAD_BALANCER_HEADER_LENGTH = LOAD_BALANCER.indexOf(LOAD_BALANCER_HEADER) + LOAD_BALANCER_HEADER.length;
+
     Object.assign(SESSION_PAYLOAD.loadBalancerCookie, {
       name: LOAD_BALANCER_HEADER,
-      value: LOAD_BALANCER.substring(
+      value: LOAD_BALANCER.toString().substring(
         LOAD_BALANCER_HEADER_LENGTH,
         LOAD_BALANCER_HEADER_LENGTH + LOAD_BALANCER.indexOf(';') - 7
       )

--- a/helpers/rest-helper.js
+++ b/helpers/rest-helper.js
@@ -9,15 +9,21 @@ const POSTRequestWrapper = async (
   postData
 ) => {
   try {
-    const response = await got.post(`${hostName}${apiPath}`, {
+    const options = {
       json: postData,
       retry: 0,
       responseType: 'json',
       headers: {
-        'Content-Type': acceptHeaderValue,
-        Cookie: authToken
+        'Content-Type': acceptHeaderValue
       }
-    });
+    };
+
+    if (authToken !== '') {
+      options.headers.Cookie = authToken;
+    }
+
+    const response = await got.post(`${hostName}${apiPath}`, options);
+
     return response;
   } catch (error) {
     console.log(

--- a/index.js
+++ b/index.js
@@ -8,14 +8,10 @@ const jira = require('./helpers/jira-helpers');
 
 const INPUT_JSON = core.getInput('INPUT_JSON') || process.env.INPUT_JSON;
 const JIRA_USER = core.getInput('JIRA_USER') || process.env.JIRA_USER;
-const JIRA_PASSWORD =
-  core.getInput('JIRA_PASSWORD') || process.env.JIRA_PASSWORD;
-const REPORT_INPUT_KEYS =
-  core.getInput('REPORT_INPUT_KEYS') || process.env.REPORT_INPUT_KEYS;
-const PRIORITY_MAPPER =
-  core.getInput('PRIORITY_MAPPER') || process.env.PRIORITY_MAPPER;
-const ISSUE_LABELS_MAPPER =
-  core.getInput('ISSUE_LABELS_MAPPER') || process.env.ISSUE_LABELS_MAPPER;
+const JIRA_PASSWORD = core.getInput('JIRA_PASSWORD') || process.env.JIRA_PASSWORD;
+const REPORT_INPUT_KEYS = core.getInput('REPORT_INPUT_KEYS') || process.env.REPORT_INPUT_KEYS;
+const PRIORITY_MAPPER = core.getInput('PRIORITY_MAPPER') || process.env.PRIORITY_MAPPER;
+const ISSUE_LABELS_MAPPER = core.getInput('ISSUE_LABELS_MAPPER') || process.env.ISSUE_LABELS_MAPPER;
 
 const startAction = async (inputJson) => {
   const jiraSession = await jira.createJiraSession(JIRA_USER, JIRA_PASSWORD);


### PR DESCRIPTION
`got` module uses a different data structure to hold the headers of a request leading to a breaking change in the current implementation.

Contributes to: camelotls/actions-jira-integration#115

Signed-off-by: Stelios Gkiokas <stelios.giokas@camelotls.com>