### PR TITLE
fix: Duplicate issue mechanism improvement

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -6,10 +6,18 @@ const JIRA_CONFIG = {
   JIRA_ISSUE_CREATION_ENDPOINT: '/rest/api/2/issue',
   JIRA_ISSUE_AUTH_SESSION_ENDPOINT: '/rest/auth/1/session',
   JIRA_ISSUE_SEARCH_ENDPOINT: '/rest/api/2/search',
-  JIRA_ISSUE_SEARCH_PAYLOAD: {
-    jql: `project=${process.env.JIRA_PROJECT || core.getInput('JIRA_PROJECT')} AND type="${'Security Vulnerability' || core.getInput('JIRA_ISSUE_TYPE')}" AND status NOT IN ("Done")`,
+  JIRA_ISSUE_SEARCH_PAYLOAD_RESOLVED_ISSUES: {
+    jql: `project=${core.getInput('JIRA_PROJECT') || process.env.JIRA_PROJECT} AND type="${core.getInput('JIRA_ISSUE_TYPE') || 'Security Vulnerability'}" AND labels IN ("${core.getInput('ISSUE_LABELS_MAPPER') || 'Security'}") AND status="Done" AND resolution IN ("Obsolete", "Duplicate", "Won't Do")`,
     startAt: 0,
-    maxResults: 100,
+    maxResults: 1000,
+    fields: [
+      'summary'
+    ]
+  },
+  JIRA_ISSUE_SEARCH_PAYLOAD_OPEN_ISSUES: {
+    jql: `project=${core.getInput('JIRA_PROJECT') || process.env.JIRA_PROJECT} AND type="${core.getInput('JIRA_ISSUE_TYPE') || 'Security Vulnerability'}" AND labels IN ("${core.getInput('ISSUE_LABELS_MAPPER') || 'Security'}") AND status NOT IN ("Done")`,
+    startAt: 0,
+    maxResults: 1000,
     fields: [
       'summary'
     ]
@@ -21,8 +29,8 @@ const REST_CONFIG = {
 };
 
 const UTILS = {
-  TEMPLATES_DIR: (process.env.RUNS_ON_GITHUB || core.getInput('RUNS_ON_GITHUB')) === 'true' ? './actions-jira-integration/templates' : './templates',
-  PAYLOADS_DIR: (process.env.RUNS_ON_GITHUB || core.getInput('RUNS_ON_GITHUB')) === 'true' ? './actions-jira-integration/payloads' : './payloads',
+  TEMPLATES_DIR: (core.getInput('RUNS_ON_GITHUB') || process.env.RUNS_ON_GITHUB) === 'true' ? './actions-jira-integration/templates' : './templates',
+  PAYLOADS_DIR: (core.getInput('RUNS_ON_GITHUB') || process.env.RUNS_ON_GITHUB) === 'true' ? './actions-jira-integration/payloads' : './payloads',
   CREATE_JIRA_ISSUE_PAYLOAD_TEMPLATE: 'issueCreation.template'
 };
 

--- a/helpers/jira-helpers.js
+++ b/helpers/jira-helpers.js
@@ -82,14 +82,14 @@ const createJiraIssue = async function (authHeaders, filePayload) {
   return response;
 };
 
-const searchExistingJiraIssues = async function (authHeaders) {
+const searchExistingJiraIssues = async function (authHeaders, payload) {
   const response = await rest.POSTRequestWrapper(
     searchExistingJiraIssues.name,
     process.env.JIRA_URI || config.JIRA_CONFIG.JIRA_URI,
     config.JIRA_CONFIG.JIRA_ISSUE_SEARCH_ENDPOINT,
     config.REST_CONFIG.HEADER_ACCEPT_APPLICATION_JSON,
     authHeaders,
-    config.JIRA_CONFIG.JIRA_ISSUE_SEARCH_PAYLOAD
+    payload
   );
 
   return response;

--- a/test/jira-helper.tests.js
+++ b/test/jira-helper.tests.js
@@ -85,7 +85,7 @@ describe('Jira REST are functioning properly', () => {
         .post(config.JIRA_CONFIG.JIRA_ISSUE_SEARCH_ENDPOINT)
         .reply(200, mocks.MOCK_JIRA_ISSUE_SEARCH_RESPONSE);
 
-      const response = await jira.searchExistingJiraIssues(authHeaders);
+      const response = await jira.searchExistingJiraIssues(authHeaders, config.JIRA_CONFIG.JIRA_ISSUE_SEARCH_PAYLOAD_OPEN_ISSUES);
       expect(response.body)
         .to.be.instanceOf(Object)
         .to.have.all.keys('expand', 'startAt', 'maxResults', 'total', 'issues');
@@ -148,7 +148,7 @@ describe('Jira REST are functioning properly', () => {
         .post(config.JIRA_CONFIG.JIRA_ISSUE_SEARCH_ENDPOINT)
         .reply(400, mocks.MOCK_JIRA_ISSUE_WRONG_SEARCH_RESPONSE);
 
-      const error = await jira.searchExistingJiraIssues(authHeaders);
+      const error = await jira.searchExistingJiraIssues(authHeaders, config.JIRA_CONFIG.JIRA_ISSUE_SEARCH_PAYLOAD_OPEN_ISSUES);
       expect(error.response.body).to.haveOwnProperty('errorMessages');
     });
 

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -60,8 +60,10 @@ const amendHandleBarTemplate = (
   try {
     beautifiedTemplate = dirtyJSON.parse(templateModifier);
     Object.assign(beautifiedTemplate.fields, issueLabelMapper);
+
     const beautifiedTemplateStringified = JSON.stringify(beautifiedTemplate);
     const isValidSchema = (jsonValidator.validate(JSON.parse(beautifiedTemplateStringified), jiraIssueSchema).errors.length === 0);
+
     try {
       if (isValidSchema) {
         fs.writeFileSync(`${config.UTILS.PAYLOADS_DIR}/${payload}`, beautifiedTemplateStringified, 'utf8');


### PR DESCRIPTION
Splitting the jql query into 2:

- the first one focuses on spotting the resolved issues
- the second, on spotting the current open issues

This is done to avoid the duplicate issue raising.

Contributes to: camelotls/actions-jira-integration#207

Signed-off-by: Stelios Gkiokas <stelios.giokas@camelotls.com>