### PR TITLE
fix: Minimise the loss of issues

### DIFF
--- a/utils/helper.js
+++ b/utils/helper.js
@@ -34,6 +34,11 @@ const jiraIssueSchema = {
 };
 const jsonValidator = new Validator();
 
+// use this function in order to minimise the losses caused in JSON parsings when boolean values are present
+const booleanToUpper = (input) => {
+  return input.replace(/true/g, 'True').replace(/false/g, 'False');
+};
+
 const amendHandleBarTemplate = (
   template,
   issueModule,
@@ -58,7 +63,7 @@ const amendHandleBarTemplate = (
 
   let beautifiedTemplate;
   try {
-    beautifiedTemplate = dirtyJSON.parse(templateModifier);
+    beautifiedTemplate = dirtyJSON.parse(booleanToUpper(templateModifier));
     Object.assign(beautifiedTemplate.fields, issueLabelMapper);
 
     const beautifiedTemplateStringified = JSON.stringify(beautifiedTemplate);


### PR DESCRIPTION
This PR attempts to minimise the loss of issues that are not raised due to the inability to parse the providing JSON input despite the fact that `dirty-json` is used. It has been noticed that the main problem lies to cases in which boolean values are supplied in the JSON input, hence the focus on this PR was on there.

Contributes to: camelotls/actions-jira-integration#93

Signed-off-by: Stelios Gkiokas <stelios.giokas@camelotls.com>