### PR TITLE
fix: Handle arrays supplied to extra fields

### DIFF
--- a/utils/helper.js
+++ b/utils/helper.js
@@ -53,7 +53,7 @@ const constructJiraIssuePayload = (
   const templateInput = template.blueprint(
     issueSummary,
     issueDescription,
-    issueSeverity
+    severityMap
   );
 
   /*

--- a/utils/template.js
+++ b/utils/template.js
@@ -21,13 +21,31 @@ const create = (templateBluePrint, extraJiraFields) => {
   const extraFieldsAtomicView = {};
 
   fieldKeys.forEach((field) => {
+    let blueprintKey = templateBluePrint[field];
+
     if (Object.keys(extraJiraFields).includes(field)) {
       // For the extra fields supplied, we need to determine the data type in order to properly construct the JSON
       // schema to be used. Array types are special data types used in that module
       const fieldType = templateBluePrint[field].match(/\[.+\]/g) !== null ? 'array' : typeof templateBluePrint[field];
+
+      if (fieldType === 'array') {
+        // TODO: The implementation below refers purely to cases that contain single element arrays since it's a hot fix
+        // for a last minute problem identified during testing. We should fix this logic to accept any length of arrays
+        // supplied.
+        const mainKey = `${field.replace('fields.', '')}`;
+        const parentArrayObject = { [mainKey]: [] };
+        const childKeyToBeQuoted = extraJiraFields[field].substring(extraJiraFields[field].indexOf('{') + 1, extraJiraFields[field].lastIndexOf(':'));
+        const childKeyValue = extraJiraFields[field].substring(extraJiraFields[field].indexOf(':') + 1, extraJiraFields[field].lastIndexOf('}')).trim();
+
+        parentArrayObject[mainKey].push({
+          [childKeyToBeQuoted]: childKeyValue
+        });
+
+        blueprintKey = parentArrayObject[mainKey];
+      }
       _.set(extraFieldsAtomicView, field, { type: fieldType });
     }
-    _.set(template, field, templateBluePrint[field]);
+    _.set(template, field, blueprintKey);
   });
 
   return { template, extraFieldsAtomicView };


### PR DESCRIPTION
This PR:

- properly handles array values if supplied to the extra Jira fields
- fixes the way the priority is read in the final issue creation

Contributes to: camelotls/actions-jira-integration#257

Signed-off-by: Stelios Gkiokas <s_giokas@hotmail.com>