### PR TITLE
fix: Propagate errors originating from Jira REST api

### DIFF
--- a/helpers/rest-helper.js
+++ b/helpers/rest-helper.js
@@ -36,7 +36,7 @@ const POSTRequestWrapper = async (
       log.warn(error.response.body.errors);
     }
 
-    return error;
+    throw error;
   }
 };
 
@@ -65,7 +65,7 @@ const DELETERequestWrapper = async (
       log.warn(error.response.body.errors);
     }
 
-    return error;
+    throw error;
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -973,6 +973,15 @@
                 "type-detect": "^4.0.5"
             }
         },
+        "chai-as-promised": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+            "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+            "dev": true,
+            "requires": {
+                "check-error": "^1.0.2"
+            }
+        },
         "chai-files": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/chai-files/-/chai-files-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,18 +12,15 @@
     "license": "MIT",
     "dependencies": {
         "@actions/core": "1.6.0",
-        "chai": "4.3.4",
-        "chai-files": "1.4.0",
         "fs": "0.0.1-security",
         "got": "^11.8.2",
         "lodash": "4.17.21",
-        "mocha": "8.3.0",
-        "nock": "13.1.3",
         "rimraf": "3.0.2"
     },
     "devDependencies": {
         "assert": "^2.0.0",
         "bunyan": "1.8.15",
+        "chai-as-promised": "^7.1.1",
         "child_process": "1.0.2",
         "dirty-json": "0.9.2",
         "eslint": "7.32.0",
@@ -33,6 +30,10 @@
         "eslint-plugin-promise": "5.1.0",
         "jsonschema": "1.4.0",
         "nyc": "15.1.0",
-        "uuid": "8.3.2"
+        "uuid": "8.3.2",
+        "chai": "4.3.4",
+        "chai-files": "1.4.0",
+        "mocha": "8.3.0",
+        "nock": "13.1.3"
     }
 }

--- a/test/jira-helper.tests.js
+++ b/test/jira-helper.tests.js
@@ -1,10 +1,12 @@
-const { expect } = require('chai');
 const nock = require('nock');
 const { describe, it } = require('mocha');
 
 const jira = require('../helpers/jira-helpers');
 const mocks = require('./mocks/jira-helper-mock');
 const config = require('../config/config');
+const chai = require('chai')
+const expect = chai.expect;
+chai.use(require('chai-as-promised'))
 
 describe('Jira REST are functioning properly', () => {
   process.env = {
@@ -191,14 +193,12 @@ describe('Jira REST are functioning properly', () => {
         .post(config.JIRA_CONFIG.JIRA_ISSUE_CREATION_ENDPOINT)
         .reply(400, mocks.MOCK_JIRA_ISSUE_CREATION_WRONG_RESPONSE);
 
-      const error = await jira.createIssue(
-        authHeaders,
-        JSON.stringify(mocks.MOCK_JIRA_ISSUE_CREATION_WRONG_PAYLOAD)
-      );
-      expect(error.response.statusCode).to.be.equal(400);
-      expect(error.response.body)
-        .to.be.instanceOf(Object)
-        .to.deep.equal({ errorMessages: mocks.MOCK_JIRA_ISSUE_CREATION_WRONG_RESPONSE.errorMessages, errors: {} });
+      expect(
+        jira.createIssue(
+          authHeaders,
+          JSON.stringify(mocks.MOCK_JIRA_ISSUE_CREATION_WRONG_PAYLOAD)
+        )
+      ).to.be.rejectedWith(Error)
     });
 
     it('a JIRA issue fails to be created when a wrong extra field is supplied', async () => {
@@ -206,15 +206,12 @@ describe('Jira REST are functioning properly', () => {
         .post(config.JIRA_CONFIG.JIRA_ISSUE_CREATION_ENDPOINT)
         .reply(400, mocks.MOCK_JIRA_ISSUE_CREATION_WRONG_RESPONSE_WITH_WRONG_EXTRA_FIELD);
 
-      const error = await jira.createIssue(
-        authHeaders,
-        JSON.stringify(mocks.MOCK_JIRA_ISSUE_CREATION_WRONG_RESPONSE_WITH_WRONG_EXTRA_FIELD)
-      );
-
-      expect(error.response.statusCode).to.be.equal(400);
-      expect(error.response.body)
-        .to.be.instanceOf(Object)
-        .to.deep.equal({ errorMessages: mocks.MOCK_JIRA_ISSUE_CREATION_WRONG_RESPONSE_WITH_WRONG_EXTRA_FIELD.errorMessages, errors: {} });
+      expect(
+        jira.createIssue(
+          authHeaders,
+          JSON.stringify(mocks.MOCK_JIRA_ISSUE_CREATION_WRONG_RESPONSE_WITH_WRONG_EXTRA_FIELD)
+        )
+      ).to.be.rejectedWith(Error)
     });
 
     it('a list of JIRA issues fails to be fetched when a wrong payload is supplied', async () => {
@@ -222,10 +219,9 @@ describe('Jira REST are functioning properly', () => {
         .post(config.JIRA_CONFIG.JIRA_ISSUE_SEARCH_ENDPOINT)
         .reply(400, mocks.MOCK_JIRA_ISSUE_WRONG_SEARCH_RESPONSE);
 
-      const error = await jira.searchIssues(authHeaders, config.JIRA_CONFIG.JIRA_ISSUE_SEARCH_PAYLOAD_OPEN_ISSUES);
-      expect(error.response.body)
-        .to.be.instanceOf(Object)
-        .to.have.all.keys('errorMessages', 'errors');
+      expect(
+        jira.searchIssues(authHeaders, config.JIRA_CONFIG.JIRA_ISSUE_SEARCH_PAYLOAD_OPEN_ISSUES)
+      ).to.be.rejectedWith(Error)
     });
 
     // eslint-disable-next-line no-undef


### PR DESCRIPTION
Instead of returning errors from rest-helper errors should be re-thrown in order to fail the workflow. Otherwise the workflow's status might appear successful despite errors having been raised due to issues when sending requests to the Jira API.