### PR TITLE
[NO JIRA] Add nullish operator in pair matcher

### DIFF
--- a/utils/helper.js
+++ b/utils/helper.js
@@ -104,7 +104,7 @@ export const reportMapper = (inputElement, parsedInput, reportPairsMapper) => {
   // eslint-disable-next-line no-unused-vars
   for (const [reportKey, reportValue] of Object.entries(reportPairsMapper)) {
     let firstPass = false;
-    const reportInputVariablesFetcher = [...reportValue.match(/\{{(.*?)\}}/g)];
+    const reportInputVariablesFetcher = [...reportValue.match(/\{{(.*?)\}}/g) ?? []];
     if (reportInputVariablesFetcher.length === 0) {
       continue;
     }


### PR DESCRIPTION
If any of the reportValue doesn't contain a `{{field}}`, `.match` will return null which causes the spread operator to throw an error "TypeError: reportValue.match is not a function or its return value is not iterable". 
Add a nullish coalescing operator and fallback to empty Array if `match` returns null.