### PR TITLE
[NO JIRA] Allow mapping without replacing fields

### DIFF
--- a/utils/helper.js
+++ b/utils/helper.js
@@ -105,7 +105,9 @@ export const reportMapper = (inputElement, parsedInput, reportPairsMapper) => {
   for (const [reportKey, reportValue] of Object.entries(reportPairsMapper)) {
     let firstPass = false;
     const reportInputVariablesFetcher = [...reportValue.match(/\{{(.*?)\}}/g) ?? []];
+    // If there are no fields to replace, map the value instantly
     if (reportInputVariablesFetcher.length === 0) {
+      mapper[reportKey] = reportValue;
       continue;
     }
 


### PR DESCRIPTION
If a value in `REPORT_INPUT_KEYS` doesn't contain a field to replace, continuing without adding to the map, causes the whole key to be missing. This leads to a payload that isn't valid for the API. (e.g issueSummary missing).