### PR TITLE
[NO-JIRA] Fix API token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A GitHub Action to integrate multiple tools with Jira Server and raise relevant 
 |Parameter|Required|Default value|Description|
 |:--:|:--:|:--:|:--:|
 |JIRA_ON_CLOUD|false|false|If you are using Jira on Cloud set this environment variable to true|
-|JIRA_CLOUD_TOKEN|false|N/A|Github secret for the JIRA basic authentication token. NOTE: Should be in base64|
+|JIRA_CLOUD_TOKEN|false|N/A|Github secret for the JIRA basic authentication token.|
 |JIRA_USER|false|N/A|GitHub secret for the JIRA user email for external access|
 |JIRA_PASSWORD|false|N/A|GitHub secret for the JIRA API token for external access|
 |JIRA_PROJECT|true|N/A|The project key for Jira|

--- a/index.js
+++ b/index.js
@@ -74,7 +74,8 @@ const logout = async (jiraAuthHeaderValue) => {
 
 const kickOffAction = async (inputJson) => {
   if (JIRA_CONFIG.JIRA_ON_CLOUD === 'true') {
-    jiraAuthHeaderValue = `Basic ${JIRA_CONFIG.JIRA_CLOUD_TOKEN}`;
+    const encodedAuthHeader = btoa(`${JIRA_CONFIG.JIRA_USER}:${JIRA_CONFIG.JIRA_CLOUD_TOKEN}`);
+    jiraAuthHeaderValue = `Basic ${encodedAuthHeader}`;
   } else {
     const jiraSession = await createSession(JIRA_CONFIG.JIRA_USER, JIRA_CONFIG.JIRA_PASSWORD);
     log.info('JIRA session created successfully!');


### PR DESCRIPTION
Jira expects the Basic authentication header to contain base64 encoded string in the format `<user@company.com>:<API token`.

See: https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/#supply-basic-auth-headers