### PR TITLE
[NO-JIRA] Switch to Jira API v3

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -8,9 +8,9 @@ export const JIRA_CONFIG = {
   JIRA_PROJECT: process.env.JIRA_PROJECT || core.getInput('JIRA_PROJECT'),
   JIRA_URI: process.env.JIRA_URI || core.getInput('JIRA_URI'),
   ISSUE_TYPE: process.env.ISSUE_TYPE || core.getInput('ISSUE_TYPE'),
-  JIRA_ISSUE_CREATION_ENDPOINT: '/rest/api/2/issue',
+  JIRA_ISSUE_CREATION_ENDPOINT: '/rest/api/3/issue',
   JIRA_ISSUE_AUTH_SESSION_ENDPOINT: '/rest/auth/1/session',
-  JIRA_ISSUE_SEARCH_ENDPOINT: '/rest/api/2/search',
+  JIRA_ISSUE_SEARCH_ENDPOINT: '/rest/api/3/search',
   JIRA_ISSUE_SEARCH_PAYLOAD_RESOLVED_ISSUES: {
     jql: process.env.JQL_SEARCH_PAYLOAD_RESOLVED_ISSUES || core.getInput('JQL_SEARCH_PAYLOAD_RESOLVED_ISSUES'),
     startAt: 0,

--- a/test/mocks/template-mock.js
+++ b/test/mocks/template-mock.js
@@ -1,0 +1,16 @@
+export const MOCK_JIRA_ISSUE_DESCRIPTION_RAW_STRING = 'This is a mock description';
+export const MOCK_JIRA_ISSUE_DESCRIPTION_ADF_STRING = {
+  type: 'doc',
+  version: 1,
+  content: [
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'This is a mock description'
+        }
+      ]
+    }
+  ]
+};

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { MOCK_JIRA_ISSUE_DESCRIPTION_RAW_STRING, MOCK_JIRA_ISSUE_DESCRIPTION_ADF_STRING } from './mocks/template-mock.js';
+
+import { MOCK_JIRA_ISSUE_SUMMARY } from './mocks/jira-helper-mock.js';
+
+import { blueprint } from '../utils/template.js';
+
+describe('should create jira issues regardless of description type', () => {
+  it('with plain string description', () => {
+    const blp = blueprint(
+      MOCK_JIRA_ISSUE_SUMMARY,
+      MOCK_JIRA_ISSUE_DESCRIPTION_RAW_STRING,
+      'P1'
+    );
+    expect(blp)
+      .to.be.instanceOf(Object)
+      .to.have.all.keys(
+        'description',
+        'summary',
+        'issuetype.name',
+        'priority.name',
+        'project.key'
+      );
+    expect(blp.description).to.deep.equal(MOCK_JIRA_ISSUE_DESCRIPTION_ADF_STRING);
+  });
+
+  it('with ADF string description', () => {
+    const blp = blueprint(
+      MOCK_JIRA_ISSUE_SUMMARY,
+      JSON.stringify(MOCK_JIRA_ISSUE_DESCRIPTION_ADF_STRING),
+      'P1'
+    );
+    expect(blp)
+      .to.be.instanceOf(Object)
+      .to.have.all.keys(
+        'description',
+        'summary',
+        'issuetype.name',
+        'priority.name',
+        'project.key'
+      );
+    expect(blp.description).to.deep.equal(MOCK_JIRA_ISSUE_DESCRIPTION_ADF_STRING);
+  });
+});

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -31,7 +31,10 @@ const jiraIssueSchemaBase = {
       type: 'array'
     },
     description: {
-      type: 'string'
+      type: 'object',
+      content: {
+        type: 'array'
+      }
     }
   }
 };
@@ -201,5 +204,28 @@ export const updateObjectKeys = (newKey, examinedObject) => {
   for (const [key, value] of Object.entries(examinedObject)) {
     Object.defineProperty(examinedObject, `${newKey}.${key}`, Object.getOwnPropertyDescriptor(examinedObject, key));
     delete examinedObject[key];
+  }
+};
+
+export const parseDescription = (issueDescription) => {
+  try {
+    return JSON.parse(issueDescription);
+  } catch (e) {
+    core.warning("issueDescription doesn't seem to be in ADF format. Assuming it's a raw string, will convert it to ADF. This may not work as expected! Consider switching to ADF format.");
+    return {
+      type: 'doc',
+      version: 1,
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: `${issueDescription}`
+            }
+          ]
+        }
+      ]
+    };
   }
 };


### PR DESCRIPTION
Jira API v3 supports [Atlassian Document Format (ADF)](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/), this allows us to format the issue description by adding paragraphs, code, lists etc.

`/rest/api/3/search` is considered [deprecated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-post). The replacement API is `/rest/api/3/search/jql` but it doesn't support unbounded searches (meaning with no JQL query defined), which is something we allow in the actions. Wondering if that's intentional since I found some [tests](https://github.com/camelotls/actions-jira-integration/blob/main/test/jira-helper.tests.js#L168-L180).

I tried to maintain compatibility with the old way of passing `issueDescription` by wrapping raw description strings into single paragraph ADF JSON objects. For building and validating ADF documents [this](https://developer.atlassian.com/cloud/jira/platform/apis/document/playground/) builder can be used.